### PR TITLE
Update to run import-users at startup too

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,8 @@ else
   sed -i 's:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g' /etc/ssh/sshd_config
 fi
 
-echo "*/10 * * * * root /opt/import_users.sh > /var/log/import-users.log 2>&1" > /etc/cron.d/import_users
+echo "@reboot root /opt/import_users.sh > /var/log/import-users.log 2>&1" > /etc/cron.d/import_users
+echo "*/10 * * * * root /opt/import_users.sh > /var/log/import-users.log 2>&1" >> /etc/cron.d/import_users
 chmod 0644 /etc/cron.d/import_users
 
 /opt/import_users.sh


### PR DESCRIPTION
Adding an `@reboot` in here to have the import of users happen during boot.  This hopefully resolves issues where you can't login with a user on a fresh instance for up to 10 minutes until the cron initially runs and imports the users.