### PR TITLE
Only install git if its not installed, only restart SSH if we modify the config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ tmpdir=`mktemp -d`
 
 cd $tmpdir
 
+# only runs if git isn't already installed
 if ! [ -x "$(command -v git)" ]; then
   if [ -f /etc/lsb-release ]; then
     sudo apt-get update


### PR DESCRIPTION
We are running apt every time chef runs on some of our machines.