### PR TITLE
scoping the users imported for SSH to certain groups

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -16,7 +16,21 @@ export AWS_ACCESS_KEY_ID="${sts[0]}"
 export AWS_SECRET_ACCESS_KEY="${sts[1]}"
 export AWS_SESSION_TOKEN="${sts[2]}"
 
-aws iam list-users --query "Users[].[UserName]" --output text | while read User; do
+aws iam get-group --group-name ops --query "Users[].[UserName]" --output text | while read User; do
+  python -mplatform | grep -qi Ubuntu && sudo /usr/sbin/adduser --gecos "" --disabled-password "$User" || /usr/sbin/adduser --comment "IAM" "$User"
+  echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
+  chmod 0440 /etc/sudoers.d/$User
+  chown -R $User:$User /home/$User
+done
+
+aws iam get-group --group-name devs --query "Users[].[UserName]" --output text | while read User; do
+  python -mplatform | grep -qi Ubuntu && sudo /usr/sbin/adduser --gecos "" --disabled-password "$User" || /usr/sbin/adduser --comment "IAM" "$User"
+  echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
+  chmod 0440 /etc/sudoers.d/$User
+  chown -R $User:$User /home/$User
+done
+
+aws iam get-group --group-name it --query "Users[].[UserName]" --output text | while read User; do
   python -mplatform | grep -qi Ubuntu && sudo /usr/sbin/adduser --gecos "" --disabled-password "$User" || /usr/sbin/adduser --comment "IAM" "$User"
   echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
   chmod 0440 /etc/sudoers.d/$User

--- a/import_users.sh
+++ b/import_users.sh
@@ -16,23 +16,13 @@ export AWS_ACCESS_KEY_ID="${sts[0]}"
 export AWS_SECRET_ACCESS_KEY="${sts[1]}"
 export AWS_SESSION_TOKEN="${sts[2]}"
 
-aws iam get-group --group-name ops --query "Users[].[UserName]" --output text | while read User; do
-  python -mplatform | grep -qi Ubuntu && sudo /usr/sbin/adduser --gecos "" --disabled-password "$User" || /usr/sbin/adduser --comment "IAM" "$User"
-  echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
-  chmod 0440 /etc/sudoers.d/$User
-  chown -R $User:$User /home/$User
-done
-
-aws iam get-group --group-name devs --query "Users[].[UserName]" --output text | while read User; do
-  python -mplatform | grep -qi Ubuntu && sudo /usr/sbin/adduser --gecos "" --disabled-password "$User" || /usr/sbin/adduser --comment "IAM" "$User"
-  echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
-  chmod 0440 /etc/sudoers.d/$User
-  chown -R $User:$User /home/$User
-done
-
-aws iam get-group --group-name it --query "Users[].[UserName]" --output text | while read User; do
-  python -mplatform | grep -qi Ubuntu && sudo /usr/sbin/adduser --gecos "" --disabled-password "$User" || /usr/sbin/adduser --comment "IAM" "$User"
-  echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
-  chmod 0440 /etc/sudoers.d/$User
-  chown -R $User:$User /home/$User
+# only add the ops, dev and it groups users as authorized SSH users to our legacy instances
+for group in ops devs it
+do
+  aws iam get-group --group-name ${group} --query "Users[].[UserName]" --output text | while read User; do
+    python -mplatform | grep -qi Ubuntu && sudo /usr/sbin/adduser --gecos "" --disabled-password "$User" || /usr/sbin/adduser --comment "IAM" "$User"
+    echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
+    chmod 0440 /etc/sudoers.d/$User
+    chown -R $User:$User /home/$User
+  done
 done


### PR DESCRIPTION
We only want users in the `devs`, `ops`, and `it` groups in our `legacy-stage` IAM to be able to SSH onto our legacy instance; this PR scopes it down to those groups.